### PR TITLE
Controller as context

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -12,6 +12,10 @@ export type ControllerProps = {
 
 }
 
+export type ControllerState = {
+  controller: ?any
+}
+
 const ControllerContext = React.createContext(null);
 
 class Controller extends React.Component<ControllerProps, ControllerState> {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -12,9 +12,7 @@ export type ControllerProps = {
 
 }
 
-export type ControllerState = {
-  controller: ?any,
-}
+const ControllerContext = React.createContext(null);
 
 class Controller extends React.Component<ControllerProps, ControllerState> {
   controller: any;
@@ -42,14 +40,12 @@ class Controller extends React.Component<ControllerProps, ControllerState> {
       return children;
     }
 
-    return React.Children.map(children, (child) => {
-      if (child.type.displayName !== 'Scene') {
-        return child;
-      }
-      const props = {...child.props, controller};
-      return <child.type {...props} />;
-    });
+    return (
+      <ControllerContext.Provider value={controller}>
+        {children}
+      </ControllerContext.Provider>
+    );
   }
 }
 
-export { Controller };
+export { Controller, ControllerContext };

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -13,7 +13,7 @@ export type ControllerProps = {
 }
 
 export type ControllerState = {
-  controller: ?any
+  controller: ?any,
 }
 
 const ControllerContext = React.createContext(null);

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -1,5 +1,6 @@
 // @flow
 import { default as React } from 'react';
+import { ControllerContext } from './Controller';
 import ScrollMagic from './lib/scrollmagic';
 import debugAddIndicators from './lib/debug.addIndicators.js';
 
@@ -228,7 +229,7 @@ class SceneBase extends React.PureComponent<SceneBaseProps, SceneBaseState> {
   }
 }
 
-class Scene extends React.PureComponent<SceneProps, {}> {
+class SceneWrapper extends React.PureComponent<SceneProps, {}> {
   static displayName = 'Scene';
 
   render() {
@@ -246,4 +247,12 @@ class Scene extends React.PureComponent<SceneProps, {}> {
   }
 }
 
-export { Scene };
+export const Scene = ({ children, ...props }) => (
+  <ControllerContext.Consumer>
+    {controller => (
+      <SceneWrapper controller={controller} {...props}>
+        {children}
+      </SceneWrapper>
+    )}
+  </ControllerContext.Consumer>
+);


### PR DESCRIPTION
The approach using `child.type.displayName` only works if the `Scene` component is a direct child of the `Controller` component.
This approach uses the React Context API to pass down the `controller` prop and allows the `Scene` component to be anywhere in the component hierarchy (if it's a child of `Controller` obviously).