### PR TITLE
Destroy controller on component unmount.

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -33,6 +33,7 @@ class Controller extends React.Component<ControllerProps, ControllerState> {
   }
 
   componentWillUnmount() {
+    this.controller.destroy();
     this.controller = null;
   }
 


### PR DESCRIPTION
Fix for #55

That caused problems when StrictMode was on as it mounted the component two times, and we ended up with two controllers while we only have one in our JSX structure.